### PR TITLE
Relationships

### DIFF
--- a/app/controllers/api/v1/items_controller.rb
+++ b/app/controllers/api/v1/items_controller.rb
@@ -4,7 +4,12 @@ class Api::V1::ItemsController < ApplicationController
   end
 
   def index
-    render json: ItemSerializer.new(Item.all)
+    items = if params[:merchant_id].nil?
+              Item.all
+            else
+              Merchant.find(params[:merchant_id]).items
+            end
+    render json: ItemSerializer.new(items)
   end
 
   def create

--- a/app/controllers/api/v1/merchants_controller.rb
+++ b/app/controllers/api/v1/merchants_controller.rb
@@ -1,6 +1,11 @@
 class Api::V1::MerchantsController < ApplicationController
   def show
-    render json: MerchantSerializer.new(Merchant.find(params[:id]))
+    merchant = if params[:item_id].nil?
+                 Merchant.find(params[:id])
+               else
+                 Item.find(params[:item_id]).merchant
+               end
+    render json: MerchantSerializer.new(merchant)
   end
 
   def index

--- a/app/serializers/item_serializer.rb
+++ b/app/serializers/item_serializer.rb
@@ -1,4 +1,6 @@
 class ItemSerializer
   include FastJsonapi::ObjectSerializer
   attributes :name, :description, :unit_price, :merchant_id
+
+  belongs_to :merchant
 end

--- a/app/serializers/merchant_serializer.rb
+++ b/app/serializers/merchant_serializer.rb
@@ -1,4 +1,6 @@
 class MerchantSerializer
   include FastJsonapi::ObjectSerializer
   attributes :name
+
+  has_many :items
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,8 +2,12 @@ Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
   namespace :api do
     namespace :v1 do
-      resources :items, except: [:new, :edit]
-      resources :merchants, except: [:new, :edit]
+      resources :items, except: [:new, :edit] do
+        get '/merchant', to: 'merchants#show'
+      end
+      resources :merchants, except: [:new, :edit] do
+
+      end
     end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,7 @@ Rails.application.routes.draw do
         get '/merchant', to: 'merchants#show'
       end
       resources :merchants, except: [:new, :edit] do
-
+        get '/items', to: 'items#index'
       end
     end
   end

--- a/spec/requests/item_request_spec.rb
+++ b/spec/requests/item_request_spec.rb
@@ -88,4 +88,16 @@ describe 'an api request' do
     expect(edited_item.unit_price).to eq(resp_item[:unit_price])
     expect(edited_item.merchant_id).to eq(resp_item[:merchant_id])
   end
+
+  it 'can show a merchant for an item' do
+    test_item = Item.first
+
+    get api_v1_item_path(test_item)
+    resp_item = JSON.parse(response.body, symbolize_names: true)[:data]
+    expect(test_item.merchant_id).to eq(resp_item[:relationships][:merchant][:data][:id].to_i)
+
+    get api_v1_item_merchant_path(test_item)
+    resp_item = JSON.parse(response.body, symbolize_names: true)[:data]
+    expect(test_item.merchant_id).to eq(resp_item[:id].to_i)
+  end
 end

--- a/spec/requests/merchant_request_spec.rb
+++ b/spec/requests/merchant_request_spec.rb
@@ -57,4 +57,29 @@ describe 'an api request' do
     expect(edited_merch.name).to eq(update_merch.name)
     expect(edited_merch.name).to eq(resp_merch[:name])
   end
+
+  it 'can show items for a merchant' do
+    test_merchant = Merchant.first
+    item_a = create(:item, merchant: test_merchant)
+    item_b = create(:item, merchant: test_merchant)
+    item_c = create(:item, merchant: Merchant.last)
+
+    get api_v1_merchant_path(test_merchant)
+    resp_merch = JSON.parse(response.body, symbolize_names: true)[:data]
+    test_merchant_items = resp_merch[:relationships][:items][:data]
+    test_item_ids = test_merchant_items.map {|item| item[:id].to_i}
+    expect(test_item_ids.count).to eq(2)
+    expect(test_item_ids).to include(item_a.id)
+    expect(test_item_ids).to include(item_b.id)
+    expect(test_item_ids).to_not include(item_c.id)
+
+    get api_v1_merchant_items_path(test_merchant)
+    resp_merch = JSON.parse(response.body, symbolize_names: true)[:data]
+    test_item_ids = test_merchant_items.map {|item| item[:id].to_i}
+    expect(test_item_ids.count).to eq(2)
+    expect(test_item_ids).to include(item_a.id)
+    expect(test_item_ids).to include(item_b.id)
+    expect(test_item_ids).to_not include(item_c.id)
+
+  end
 end


### PR DESCRIPTION
Now allows an item to return its merchant through the /items/:id/merchant path, as well as a merchant to return its items through the /merchant/:id/items path. 